### PR TITLE
[RFC] [Behat] More precise tags

### DIFF
--- a/features/administrator_checks_a_commented_order.feature
+++ b/features/administrator_checks_a_commented_order.feature
@@ -1,4 +1,4 @@
-@order_comments
+@administrator_order_comments
 Feature: Reading comments from a customer
     In order to let customers communicate with the administrators and solve problems in their orders
     As an Administrator

--- a/features/commenting_an_order_by_a_customer.feature
+++ b/features/commenting_an_order_by_a_customer.feature
@@ -1,4 +1,4 @@
-@order_comments
+@customer_order_comments
 Feature: Commenting an order by a customer
     In order to provide ability to comment an order
     As a Customer

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius_order_comment_plugin.behat.domain.order_comments" class="Tests\Sylius\OrderCommentsPlugin\Behat\Context\Domain\OrderCommentsContext">
+        <service id="sylius_order_comment_plugin.behat.domain.customer_order_comments" class="Tests\Sylius\OrderCommentsPlugin\Behat\Context\Domain\OrderCommentsContext">
             <argument type="service" id="sylius.behat.shared_storage" />
             <tag name="fob.context_service" />
         </service>
-        <service id="sylius_order_comment_plugin.behat.application.order_comments" class="Tests\Sylius\OrderCommentsPlugin\Behat\Context\Application\OrderCommentsContext">
+        <service id="sylius_order_comment_plugin.behat.application.customer_order_comments" class="Tests\Sylius\OrderCommentsPlugin\Behat\Context\Application\OrderCommentsContext">
             <argument type="service" id="__symfony__.command_bus" />
             <argument type="service" id="__symfony__.sylius.repository.order_comment" />
             <argument type="service" id="sylius.behat.shared_storage" />

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -1,3 +1,3 @@
 imports:
-    - suites/domain/order_comments.yml
-    - suites/application/order_comments.yml
+    - suites/domain/customer_order_comments.yml
+    - suites/application/customer_order_comments.yml

--- a/tests/Behat/Resources/suites/application/customer_order_comments.yml
+++ b/tests/Behat/Resources/suites/application/customer_order_comments.yml
@@ -2,7 +2,7 @@
 
 default:
     suites:
-        domain_order_comments:
+        application_customer_order_comments:
             contexts_services:
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.email_spool
@@ -23,6 +23,6 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
 
-                - sylius_order_comment_plugin.behat.domain.order_comments
+                - sylius_order_comment_plugin.behat.application.customer_order_comments
             filters:
-                tags: "@order_comments && @domain"
+                tags: "@customer_order_comments && @application"

--- a/tests/Behat/Resources/suites/domain/customer_order_comments.yml
+++ b/tests/Behat/Resources/suites/domain/customer_order_comments.yml
@@ -2,7 +2,7 @@
 
 default:
     suites:
-        application_order_comments:
+        domain_customer_order_comments:
             contexts_services:
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.email_spool
@@ -23,6 +23,6 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
 
-                - sylius_order_comment_plugin.behat.application.order_comments
+                - sylius_order_comment_plugin.behat.domain.customer_order_comments
             filters:
-                tags: "@order_comments && @application"
+                tags: "@customer_order_comments && @domain"


### PR DESCRIPTION
Just a proposition. I have to differentiate somehow customer and admin context and it can be weird if only admin will have some prefix in a tag. So my proposal is to prefix both tags: for customer and admin.

Another option is to have just `@admin` and `@customer` tags, as this will be a real distinction between contexts. 