### PR TITLE
[Maintenance] Upgrade PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^3.2",
-        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit": "^6.0",
         "behat/behat": "^3.3",
         "behat/mink": "^1.7",
         "behat/mink-browserkit-driver": "^1.3",

--- a/tests/Comments/Application/Command/CommentOrderByCustomerTest.php
+++ b/tests/Comments/Application/Command/CommentOrderByCustomerTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\OrderCommentsPlugin\Comments\Application\Command;
 
+use PHPUnit\Framework\TestCase;
 use Sylius\OrderCommentsPlugin\Application\Command\CommentOrderByCustomer;
 
-final class CommentOrderByCustomerTest extends \PHPUnit_Framework_TestCase
+final class CommentOrderByCustomerTest extends TestCase
 {
     /**
      * @test

--- a/tests/Comments/Domain/Event/OrderCommentedByAdministratorTest.php
+++ b/tests/Comments/Domain/Event/OrderCommentedByAdministratorTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\OrderCommentsPlugin\Comments\Event;
 
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Core\Model\Order;
 use Sylius\OrderCommentsPlugin\Domain\Event\OrderCommentedByAdministrator;
-use Sylius\OrderCommentsPlugin\Domain\Event\OrderCommentedByCustomer;
 use Sylius\OrderCommentsPlugin\Domain\Model\Email;
 
-final class OrderCommentedByAdministratorTest extends \PHPUnit_Framework_TestCase
+final class OrderCommentedByAdministratorTest extends TestCase
 {
     /**
      * @test

--- a/tests/Comments/Domain/Event/OrderCommentedByCustomerTest.php
+++ b/tests/Comments/Domain/Event/OrderCommentedByCustomerTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\OrderCommentsPlugin\Comments\Event;
 
+use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Core\Model\Order;
 use Sylius\OrderCommentsPlugin\Domain\Event\OrderCommentedByCustomer;
 use Sylius\OrderCommentsPlugin\Domain\Model\Email;
 
-final class OrderCommentedByCustomerTest extends \PHPUnit_Framework_TestCase
+final class OrderCommentedByCustomerTest extends TestCase
 {
     /**
      * @test

--- a/tests/Comments/Domain/Model/CommentTest.php
+++ b/tests/Comments/Domain/Model/CommentTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\OrderCommentsPlugin\Comments\Domain\Model;
 
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\Order;
-use Sylius\OrderCommentsPlugin\Domain\Model\Author;
 use Sylius\OrderCommentsPlugin\Domain\Model\Comment;
-use Sylius\OrderCommentsPlugin\Domain\Model\Email;
 
-final class CommentTest extends \PHPUnit_Framework_TestCase
+final class CommentTest extends TestCase
 {
     /**
      * @test

--- a/tests/Comments/Domain/Model/EmailTest.php
+++ b/tests/Comments/Domain/Model/EmailTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\OrderCommentsPlugin\Comments\Domain\Model;
 
+use PHPUnit\Framework\TestCase;
 use Sylius\OrderCommentsPlugin\Domain\Model\Email;
 
-final class EmailTest extends \PHPUnit_Framework_TestCase
+final class EmailTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Is based on and closes #16.

I've opened another PR, to allow for discussion for upgrading a version it self. Tests should be green, so I don't see any problem in moving forward, but maybe you are aware of any limitations? Anyway, in a worst case, we can always migrate down.